### PR TITLE
Forward synchronization: have an option NOT to keep local copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,9 @@ The pivot used for the synchronization in the LSC connector is the email address
 
 The destination attribute for the LSC forwards connector is named `forwards`.
 
+Be default, local copy forwards from LDAP would not be synchronized. To allow to synchronize local copy forwards, add 
+the following JVM property when run the LSC script: `-Dallow.synchronize.local.copy.forwards=true`.
+
 #### Supported operations
 - **Create**: If a user has no forward in James, but has some forwards in LDAP, then those forwards would be created on James.
 - **Update**: If a user has some forwards in James, but there are some forwards in LDAP that do not exist yet for the user in James side, those forwards would be created.

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ dn: uid=rkowalsky,ou=users,dc=linagora.com,dc=lng
 [...]
 mail: rkowalsky@linagora.com
 otherMailbox: forward1@linagora.com
-otherMailbox: forward2@linagora.com
+otherMailbox: rkowalsky@linagora.com
 ```
 
 This will be represented as the following TMail address forwards:
@@ -241,10 +241,15 @@ This will be represented as the following TMail address forwards:
 $ curl -XGET http://ip:port/address/forwards/rkowalsky@linagora.com
 
 [
-  {"mailAddress":"forward1@linagora.com"},
-  {"mailAddress":"forward2@linagora.com"}
+  {"mailAddress":"forward1@linagora.com"}
 ]
 ```
+
+Be default, local copy forwards from LDAP (e.g. `rkowalsky@linagora.com` in the above case) would not be synchronized.
+
+To allow synchronizing local copy forwards, add
+the following JVM property when run the LSC script: `-Dallow.synchronize.local.copy.forwards=true`.
+Setting this property to `false` or omitting this property would not synchronize local copy forwards.
 
 As addresses forwards in TMail are only created if there are some sources, an LDAP entry without `otherMailbox` attribute won't be synchronized.
 
@@ -253,9 +258,6 @@ Please notice that users need to be created in James before creating forwards fo
 The pivot used for the synchronization in the LSC connector is the email address, here `rkowalsky@linagora.com` stored in the `email` attribute.
 
 The destination attribute for the LSC forwards connector is named `forwards`.
-
-Be default, local copy forwards from LDAP would not be synchronized. To allow to synchronize local copy forwards, add 
-the following JVM property when run the LSC script: `-Dallow.synchronize.local.copy.forwards=true`.
 
 #### Supported operations
 - **Create**: If a user has no forward in James, but has some forwards in LDAP, then those forwards would be created on James.

--- a/sample/ldap-to-james-forward/lsc.xml
+++ b/sample/ldap-to-james-forward/lsc.xml
@@ -25,7 +25,7 @@
   <audits/>
   <tasks>
     <task>
-      <name>identitySynchronization</name>
+      <name>forwardSynchronization</name>
       <bean>org.lsc.beans.SimpleBean</bean>
       <ldapSourceService>
         <name>openldap-user</name>
@@ -36,24 +36,22 @@
         </pivotAttributes>
         <fetchedAttributes>
           <string>mail</string>
-          <string>givenName</string>
-          <string>sn</string>
+          <string>otherMailbox</string>
         </fetchedAttributes>
         <getAllFilter>(&amp;(objectClass=inetOrgPerson)(mail=*))</getAllFilter>
         <getOneFilter>(&amp;(objectClass=inetOrgPerson)(mail={mail}))</getOneFilter>
         <cleanFilter>(&amp;(objectClass=inetOrgPerson)(mail={email}))</cleanFilter>
       </ldapSourceService>
-      <pluginDestinationService implementationClass="org.lsc.plugins.connectors.james.JamesIdentityDstService">
-        <name>james-identity-dst</name>
+      <pluginDestinationService implementationClass="org.lsc.plugins.connectors.james.JamesForwardDstService">
+        <name>james-forward-dst</name>
         <connection reference="james" />
-        <james:jamesIdentityService>
-          <name>james-identity-service-dst</name>
+        <james:jamesForwardService>
+          <name>james-forward-service-dst</name>
           <connection reference="james" />
           <james:writableAttributes>
-            <string>firstname</string>
-            <string>surname</string>
+            <string>forwards</string>
           </james:writableAttributes>
-        </james:jamesIdentityService>
+        </james:jamesForwardService>
       </pluginDestinationService>
       <propertiesBasedSyncOptions>
         <mainIdentifier>srcBean.getDatasetFirstValueById('mail');</mainIdentifier>
@@ -61,8 +59,8 @@
         <defaultPolicy>FORCE</defaultPolicy>
         <conditions>
           <create>true</create>
-          <update>false</update>
-          <delete>false</delete>
+          <update>true</update>
+          <delete>true</delete>
           <changeId>false</changeId>
         </conditions>
         <dataset>
@@ -72,15 +70,9 @@
           </forceValues>
         </dataset>
         <dataset>
-          <name>firstname</name>
+          <name>forwards</name>
           <forceValues>
-            <string>srcBean.getDatasetFirstValueById("givenName")</string>
-          </forceValues>
-        </dataset>
-        <dataset>
-          <name>surname</name>
-          <forceValues>
-            <string>srcBean.getDatasetFirstValueById("sn")</string>
+            <string>srcBean.getDatasetValuesById("otherMailbox")</string>
           </forceValues>
         </dataset>
       </propertiesBasedSyncOptions>


### PR DESCRIPTION
resolve https://github.com/linagora/tmail-lsc/issues/15

For address mappings synchronization, we do not need this. Because address mappings do not accept a local copy (same source and destination address).