### PR TITLE
Update Jenkinsfile - using jdk tool instead of agent label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,7 @@
 pipeline {
-    agent {
-      label 'jdk11'
+    agent any
+    tools {
+        jdk 'jdk_11'
     }
     stages {
         stage('Compile') {


### PR DESCRIPTION
We need to adapt the ticket update regarding James Jenkins: https://github.com/linagora/james-project-private/issues/923.