### PR TITLE
ISSUE-30 Domain contact synchronization should filter wished domains when get list pivots

### DIFF
--- a/src/main/java/org/lsc/plugins/connectors/james/JamesDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/james/JamesDao.java
@@ -695,14 +695,33 @@ public class JamesDao {
 		}
 	}
 
-	public List<User> getUsersListViaDomainContacts() {
+	public List<User> getAllDomainsContacts() {
 		WebTarget target = contactsClient.path("/domains/contacts/all");
-		LOGGER.debug("GETting users with domain contacts list: " + target.getUri().toString());
+		LOGGER.debug("GETting users with all domain contacts list: " + target.getUri().toString());
 		List<String> users = target.request()
 			.header(HttpHeaders.AUTHORIZATION, authorizationBearer)
 			.get(new GenericType<List<String>>(){});
 		return users.stream()
 			.map(User::new)
+			.collect(Collectors.toList());
+	}
+
+	public List<User> getDomainContactsByDomains(List<String> domains) {
+		return domains.stream()
+			.flatMap(domain -> getContactsOfDomain(domain).stream())
+			.map(User::new)
+			.collect(Collectors.toList());
+	}
+
+	private List<String> getContactsOfDomain(String domain) {
+		WebTarget target = contactsClient.path("/domains/{domain}/contacts")
+			.resolveTemplate("domain", domain);
+		LOGGER.debug("GETting contact email addresses of domain: " + domain);
+
+		return target.request()
+			.header(HttpHeaders.AUTHORIZATION, authorizationBearer)
+			.get(new GenericType<List<String>>() {})
+			.stream()
 			.collect(Collectors.toList());
 	}
 

--- a/src/main/java/org/lsc/plugins/connectors/james/TMailContactDstService.java
+++ b/src/main/java/org/lsc/plugins/connectors/james/TMailContactDstService.java
@@ -148,7 +148,7 @@ public class TMailContactDstService implements IWritableService {
     @Override
     public Map<String, LscDatasets> getListPivots() throws LscServiceException {
         try {
-            List<User> userList = jamesDao.getUsersListViaDomainContacts();
+            List<User> userList = getDomainContacts();
             Map<String, LscDatasets> listPivots = new HashMap<>();
             for (User user : userList) {
                 listPivots.put(user.email, user.toDatasets());
@@ -163,6 +163,12 @@ public class TMailContactDstService implements IWritableService {
             LOGGER.debug(e.toString(), e);
             throw new LscServiceException(e);
         }
+    }
+
+    private List<User> getDomainContacts() {
+        return SyncContactConfig.DOMAIN_LIST_TO_SYNCHRONIZE
+            .map(jamesDao::getDomainContactsByDomains)
+            .orElseGet(jamesDao::getAllDomainsContacts);
     }
 
     private Contact extractContact(LscModifications lscModifications) {

--- a/src/test/java/org/lsc/plugins/connectors/james/TMailContactDstServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/james/TMailContactDstServiceTest.java
@@ -154,7 +154,7 @@ class TMailContactDstServiceTest {
 
     @AfterEach
     void removeAllContact() {
-        jamesDao.getUsersListViaDomainContacts()
+        jamesDao.getAllDomainsContacts()
                 .forEach(user -> jamesDao.removeDomainContact(user.email));
     }
 
@@ -197,6 +197,35 @@ class TMailContactDstServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(listPivots).hasSize(2);
             softly.assertThat(listPivots).containsOnlyKeys(CONTACT_RENE.getEmailAddress(), CONTACT_TUNG.getEmailAddress());
+        });
+    }
+
+    @Test
+    void getListPivotsShouldReturnAllDomainContactsByDefault() throws Exception {
+        // If we do not configure the DOMAIN_LIST_TO_SYNCHRONIZE which means we synchronize all domains by default
+        forceSynchronizeDomainListValue(Optional.empty());
+        createContact(CONTACT_RENE);
+        createContact(CONTACT_WITH_UN_WISHED_DOMAIN);
+
+        Map<String, LscDatasets> listPivots = testee.getListPivots();
+
+        assertSoftly(softly -> {
+            softly.assertThat(listPivots).hasSize(2);
+            softly.assertThat(listPivots).containsOnlyKeys(CONTACT_RENE.getEmailAddress(), CONTACT_WITH_UN_WISHED_DOMAIN.getEmailAddress());
+        });
+    }
+
+    @Test
+    void getListPivotsShouldReturnOnlyWishedDomainContactsWhenConfigured() throws Exception {
+        forceSynchronizeDomainListValue(Arrays.asList("james.org"));
+        createContact(CONTACT_RENE);
+        createContact(CONTACT_WITH_UN_WISHED_DOMAIN);
+
+        Map<String, LscDatasets> listPivots = testee.getListPivots();
+
+        assertSoftly(softly -> {
+            softly.assertThat(listPivots).hasSize(1);
+            softly.assertThat(listPivots).containsOnlyKeys(CONTACT_RENE.getEmailAddress());
         });
     }
 


### PR DESCRIPTION
Solves noise error logs:

```java
Jan 20 03:11:32 - ERROR - Error while synchronizing ID xxx@govmu.org: java.lang.Exception: Technical problem while applying modifications to destination service
# Mon Jan 20 03:11:32 UTC 2025
dn: xxx@govmu.org
changetype: delete

Jan 20 03:11:32 - ERROR - All entries: 9549, to modify entries: 9456, successfully modified entries: 1, errors: 9455
```

cf https://github.com/linagora/tmail-lsc/issues/30#issuecomment-2601269918