### PR TITLE
Skip alias creation when alias = email

### DIFF
--- a/src/main/java/org/lsc/plugins/connectors/james/JamesDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/james/JamesDao.java
@@ -195,6 +195,11 @@ public class JamesDao {
 	}
 
 	private boolean createAddressMapping(User user, AddressMapping addressMapping) {
+		if (addressMapping.getMapping().equals(user.email)) {
+			LOGGER.debug("Address mapping source is the same as user email, skipping address mapping creation");
+			return true;
+		}
+
 		try {
 			WebTarget target = addressMappingsClient.path(String.format(ADDRESS_MAPPING_PATH, user.email, urlEncode(addressMapping.getMapping())));
 			LOGGER.debug("Creating address mapping: " + target.getUri().toString());

--- a/src/main/java/org/lsc/plugins/connectors/james/JamesDao.java
+++ b/src/main/java/org/lsc/plugins/connectors/james/JamesDao.java
@@ -509,6 +509,11 @@ public class JamesDao {
 	}
 
 	private boolean createAlias(User user, Alias alias) {
+		if (alias.source.equals(user.email)) {
+			LOGGER.debug("Alias source is the same as user email, skipping alias creation");
+			return true;
+		}
+
 		try {
 			WebTarget target = aliasesClient.path(user.email).path("sources").path(urlEncode(alias.source));
 			LOGGER.debug("PUTting alias: " + target.getUri().toString());

--- a/src/test/java/org/lsc/plugins/connectors/james/JamesAddressMappingDstServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/james/JamesAddressMappingDstServiceTest.java
@@ -374,6 +374,28 @@ class JamesAddressMappingDstServiceTest {
 	}
 
 	@Test
+	void updateShouldBeIgnoredWhenAddressMappingEqualsEmail() throws Exception {
+		createUser(BOB);
+
+		LscModifications modifications = new LscModifications(LscModificationType.UPDATE_OBJECT);
+		modifications.setMainIdentifer(BOB);
+		LscDatasetModification modification = new LscDatasetModification(
+				LscDatasetModificationType.REPLACE_VALUES, "addressMappings", ImmutableList.of(BOB));
+		modifications.setLscAttributeModifications(ImmutableList.of(modification));
+
+		boolean applied = testee.apply(modifications);
+
+		assertThat(applied).isTrue();
+
+		with()
+			.basePath("/mappings/user")
+		.get(BOB)
+			.then()
+			.statusCode(HttpStatus.SC_OK)
+			.body("mapping",  hasSize(0));
+	}
+
+	@Test
 	void updateWhenAUserWithoutAddressMappingsInJamesButSubAddressMappingInLdapShouldCreateTheSubAddressMappingSuccessfully() throws Exception {
 		createUser(BOB);
 

--- a/src/test/java/org/lsc/plugins/connectors/james/JamesAliasDstServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/james/JamesAliasDstServiceTest.java
@@ -437,7 +437,29 @@ class JamesAliasDstServiceTest {
 			.body("source", hasSize(1))
 			.body("[0].source", equalTo(subAddressingAlias));
 	}
-	
+
+	@Test
+	void createShouldBeIgnoredWhenAliasEqualsEmail() throws Exception {
+		String email = "user@james.org";
+		String alias = "user@james.org";
+
+		testee = new JamesAliasDstService(task);
+
+		LscModifications modifications = new LscModifications(LscModificationType.CREATE_OBJECT);
+		modifications.setMainIdentifer(email);
+		LscDatasetModification aliasesModification = new LscDatasetModification(
+			LscDatasetModificationType.REPLACE_VALUES, "sources", ImmutableList.of(alias));
+		modifications.setLscAttributeModifications(ImmutableList.of(aliasesModification));
+
+		boolean applied = testee.apply(modifications);
+
+		assertThat(applied).isTrue();
+		with()
+			.get(email)
+		.then()
+			.body("source", hasSize(0));
+	}
+
 	@Test
 	public void updateWithNoSourceAttributeModificationShouldFail() throws Exception {
 		String email = "user@james.org";

--- a/src/test/java/org/lsc/plugins/connectors/james/JamesForwardDstServiceTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/james/JamesForwardDstServiceTest.java
@@ -355,6 +355,23 @@ class JamesForwardDstServiceTest {
 			.body("[0].mailAddress", equalTo(ALICE));
 	}
 
+	@Test
+	void createForwardShouldBeIgnoredWhenForwardEqualsEmail() throws Exception {
+		LscModifications modifications = new LscModifications(LscModificationType.CREATE_OBJECT);
+		modifications.setMainIdentifer(BOB);
+		LscDatasetModification lscDatasetModification = new LscDatasetModification(
+			LscDatasetModificationType.ADD_VALUES, "forwards", ImmutableList.of(BOB));
+		modifications.setLscAttributeModifications(ImmutableList.of(lscDatasetModification));
+
+		boolean applied = testee.apply(modifications);
+
+		assertThat(applied).isTrue();
+		with()
+			.get(BOB)
+		.then()
+			.statusCode(HttpStatus.SC_NOT_FOUND);
+	}
+
 
 	@Test
 	void createShouldSucceedWhenAddingOneUserWithTwoForwards() throws Exception {


### PR DESCRIPTION
Should silient the following error logs:
```java
Apr 07 11:01:04 - ERROR - Error 409 (Conflict - {"statusCode":409,"type":"WrongState","message":"'xxx@xxx.org' already have associated mappings: forward:xxx@xxx.org","details":null}) while creating alias: http://192.168.43.69:8000/address/aliases/xxx@xxx.org/sources/xxx%xxx.org
Apr 07 11:01:04 - ERROR - Error while synchronizing ID xxx@xxx.org: java.lang.Exception: Technical problem while applying modifications to the destination
Apr 07 11:01:04 - ERROR - All entries: 258, to modify entries: 1, successfully modified entries: 0, errors: 1
```
