### PR TITLE
Add an integration test for LSC + Webadmin password enabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
     agent any
+    environment {
+        MAVEN_OPTS = '-Djdk.tls.client.protocols=TLSv1.2'
+    }
     tools {
         jdk 'jdk_11'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
 			<plugin>
 				<artifactId>exec-maven-plugin</artifactId>
 				<groupId>org.codehaus.mojo</groupId>
+                <version>3.6.2</version>
 				<executions>
 					<execution>
 						<id>Build TMail-LSC Image from dockerfile</id>
@@ -208,13 +209,6 @@
 				</executions>
 			</plugin>
 		</plugins>
-		<extensions>
-			<extension>
-				<groupId>org.apache.maven.wagon</groupId>
-				<artifactId>wagon-ssh</artifactId>
-				<version>2.12</version>
-			</extension>
-		</extensions>
 	</build>
 
 	<repositories>
@@ -222,32 +216,11 @@
 			<id>lsc-site</id>
 			<url>http://lsc-project.org/maven</url>
 		</repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
 	</repositories>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>Codehaus Snapshot</id>
-			<url>https://nexus.codehaus.org/content/repositories/codehaus-snapshots/</url>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-		</pluginRepository>
-		<pluginRepository>
-			<id>Codehaus</id>
-			<url>https://nexus.codehaus.org/content/repositories/releases/</url>
-			<snapshots>
-				<enabled>true</enabled>
-				<updatePolicy>always</updatePolicy>
-			</snapshots>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-		</pluginRepository>
-	</pluginRepositories>
 
 	<dependencies>
 		<dependency>

--- a/src/test/java/org/lsc/plugins/connectors/james/integration/WebadminPasswordIntegrationTest.java
+++ b/src/test/java/org/lsc/plugins/connectors/james/integration/WebadminPasswordIntegrationTest.java
@@ -1,0 +1,149 @@
+package org.lsc.plugins.connectors.james.integration;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.EncoderConfig.encoderConfig;
+import static io.restassured.config.RestAssuredConfig.newConfig;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.core.Is.is;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.apache.http.HttpStatus;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.MountableFile;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+
+class WebadminPasswordIntegrationTest {
+    private static final String DOMAIN = "james.org";
+    private static final String BOB = "bob@james.org";
+    private static final String ALICE = "alice@james.org";
+    private static final String JAMES_WEBADMIN_PASSWORD = "verybigsecret";
+    private static final int JAMES_WEBADMIN_PORT = 8000;
+    private static final int LDAP_PORT = 389;
+    private static final ConditionFactory await = await()
+        .pollDelay(Duration.ofSeconds(1))
+        .timeout(Duration.ofSeconds(10));
+
+    private GenericContainer<?> jamesContainer;
+    private GenericContainer<?> ldapContainer;
+    private GenericContainer<?> lscContainer;
+    private RequestSpecification requestSpecification;
+
+    @BeforeEach
+    void setup() {
+        Network network = Network.newNetwork();
+        jamesContainer = createJamesContainer(network);
+        jamesContainer.start();
+
+        ldapContainer = createLdapContainer(network);
+        ldapContainer.start();
+
+        lscContainer = createLscContainer(network)
+            .dependsOn(jamesContainer, ldapContainer);
+
+        requestSpecification = new RequestSpecBuilder().setPort(jamesContainer.getMappedPort(JAMES_WEBADMIN_PORT))
+            .setContentType(ContentType.JSON).setAccept(ContentType.JSON)
+            .setConfig(newConfig().encoderConfig(encoderConfig().defaultContentCharset(StandardCharsets.UTF_8)))
+            .addHeader("Authorization", "Bearer " + JAMES_WEBADMIN_PASSWORD)
+            .setBasePath("")
+            .build();
+
+        given(requestSpecification).basePath("/domains").put(DOMAIN).then().statusCode(HttpStatus.SC_NO_CONTENT);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jamesContainer.close();
+        ldapContainer.close();
+        if (lscContainer.isRunning()) {
+            lscContainer.close();
+        }
+    }
+
+    private GenericContainer<?> createJamesContainer(Network network) {
+        GenericContainer<?> james = new GenericContainer<>("linagora/tmail-backend:memory-branch-master")
+            .withNetworkAliases("james")
+            .withNetwork(network)
+            .withExposedPorts(JAMES_WEBADMIN_PORT);
+        james.withCopyFileToContainer(MountableFile.forClasspathResource("conf/webadmin-password/webadmin.properties"), "/root/conf/");
+        // JWT key for JMAP...
+        james.withCopyFileToContainer(MountableFile.forClasspathResource("conf/jwt_publickey"), "/root/conf/");
+        james.withCopyFileToContainer(MountableFile.forClasspathResource("conf/jwt_privatekey"), "/root/conf/");
+        return james.waitingFor(new LogMessageWaitStrategy().withRegEx(".*JAMES server started.*\\n").withTimes(1)
+            .withStartupTimeout(Duration.ofMinutes(3)));
+    }
+
+    private GenericContainer<?> createLdapContainer(Network network) {
+        return new GenericContainer<>(
+            new ImageFromDockerfile()
+                .withFileFromClasspath("populate.ldif", "prepopulated-ldap/populate.ldif")
+                .withFileFromClasspath("Dockerfile", "prepopulated-ldap/Dockerfile"))
+            .withNetworkAliases("ldap")
+            .withNetwork(network)
+            .withEnv("SLAPD_DOMAIN", "james.org")
+            .withEnv("SLAPD_PASSWORD", "mysecretpassword")
+            .withEnv("SLAPD_CONFIG_PASSWORD", "mysecretpassword")
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("team-mail-openldap-testing" + UUID.randomUUID()))
+            .withExposedPorts(LDAP_PORT)
+            .waitingFor(new LogMessageWaitStrategy().withRegEx(".*slapd starting*\\n")
+            .withTimes(1)
+            .withStartupTimeout(Duration.ofMinutes(3)));
+    }
+
+    private GenericContainer<?> createLscContainer(Network network) {
+        return new GenericContainer<>("linagora/tmail-lsc:latest")
+            .withNetworkAliases("lsc")
+            .withNetwork(network)
+            .withCommand("./lsc JAVA_OPTS=\"-DLSC.PLUGINS.PACKAGEPATH=org.lsc.plugins.connectors.james.generated\" --config /opt/lsc/conf/ --synchronize all --threads 1")
+            .withCopyFileToContainer(MountableFile.forClasspathResource("lsc-conf/logback.xml"), "/opt/lsc/conf/")
+            .withCopyFileToContainer(MountableFile.forClasspathResource("lsc-conf/identity/webadmin-password/lsc.xml"), "/opt/lsc/conf/")
+            .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withName("tmail-lsc-testing" + UUID.randomUUID()));
+    }
+
+    private void runLscContainer() {
+        lscContainer
+            .waitingFor(new LogMessageWaitStrategy().withRegEx(".*successfully modified entries:.*\\n")
+                .withTimes(1)
+                .withStartupTimeout(Duration.ofMinutes(2)))
+            .start();
+    }
+
+    @Test
+    void lscJobShouldCreateDefaultIdentityWhenWebadminPasswordEnabled() {
+        // GIVEN BOB and ALICE entries in LDAP, while they have no default identity on James yet
+
+        // RUN the LSC identity job
+        runLscContainer();
+
+        // THEN BOB and ALICE should have default identity provisioned
+        await.untilAsserted(() -> {
+            assertThatCode(() -> {
+                given(requestSpecification)
+                    .get(String.format("/users/%s/identities?default=true", BOB))
+                .then()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body("[0].name", is("bobFirstname bobSurname"));
+
+                given(requestSpecification)
+                    .get(String.format("/users/%s/identities?default=true", ALICE))
+                .then()
+                    .statusCode(HttpStatus.SC_OK)
+                    .body("[0].name", is("aliceFirstname aliceSurname"));
+            }).doesNotThrowAnyException();
+        });
+    }
+
+}

--- a/src/test/resources/conf/webadmin-password/webadmin.properties
+++ b/src/test/resources/conf/webadmin-password/webadmin.properties
@@ -1,0 +1,8 @@
+enabled=true
+port=8000
+cors.enable=true
+cors.origin=*
+host=0.0.0.0
+https.enabled=false
+jwt.enabled=false
+password=verybigsecret

--- a/src/test/resources/lsc-conf/identity/webadmin-password/lsc.xml
+++ b/src/test/resources/lsc-conf/identity/webadmin-password/lsc.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" ?>
+<lsc xmlns="http://lsc-project.org/XSD/lsc-core-2.1.xsd" xmlns:james="http://lsc-project.org/XSD/lsc-james0-plugin-1.0.xsd" revision="0">
+  <connections>
+    <ldapConnection>
+      <name>openldap</name>
+      <url>ldap://ldap:389/dc=james,dc=org</url>
+      <username>cn=admin,dc=james,dc=org</username>
+      <password>mysecretpassword</password>
+      <authentication>SIMPLE</authentication>
+      <referral>THROW</referral>
+      <derefAliases>NEVER</derefAliases>
+      <version>VERSION_3</version>
+      <pageSize>-1</pageSize>
+      <factory>com.sun.jndi.ldap.LdapCtxFactory</factory>
+      <tlsActivated>false</tlsActivated>
+      <saslMutualAuthentication>false</saslMutualAuthentication>
+    </ldapConnection>
+    <pluginConnection implementationClass="org.lsc.plugins.connectors.james.generated.jamesConnectionType">
+      <name>james</name>
+      <url>http://james:8000/</url>
+      <username>whatever</username>
+      <password>verybigsecret</password>
+    </pluginConnection>
+  </connections>
+  <audits/>
+  <tasks>
+    <task>
+      <name>identitySynchronization</name>
+      <bean>org.lsc.beans.SimpleBean</bean>
+      <ldapSourceService>
+        <name>openldap-user</name>
+        <connection reference="openldap"/>
+        <baseDn>ou=people,dc=james,dc=org</baseDn>
+        <pivotAttributes>
+          <string>mail</string>
+        </pivotAttributes>
+        <fetchedAttributes>
+          <string>mail</string>
+          <string>givenName</string>
+          <string>sn</string>
+        </fetchedAttributes>
+        <getAllFilter>(&amp;(objectClass=inetOrgPerson)(mail=*))</getAllFilter>
+        <getOneFilter>(&amp;(objectClass=inetOrgPerson)(mail={mail}))</getOneFilter>
+        <cleanFilter>(&amp;(objectClass=inetOrgPerson)(mail={email}))</cleanFilter>
+      </ldapSourceService>
+      <pluginDestinationService implementationClass="org.lsc.plugins.connectors.james.JamesIdentityDstService">
+        <name>james-identity-dst</name>
+        <connection reference="james" />
+        <james:jamesIdentityService>
+          <name>james-identity-service-dst</name>
+          <connection reference="james" />
+          <james:writableAttributes>
+            <string>firstname</string>
+            <string>surname</string>
+          </james:writableAttributes>
+        </james:jamesIdentityService>
+      </pluginDestinationService>
+      <propertiesBasedSyncOptions>
+        <mainIdentifier>srcBean.getDatasetFirstValueById('mail');</mainIdentifier>
+        <defaultDelimiter>;</defaultDelimiter>
+        <defaultPolicy>FORCE</defaultPolicy>
+        <conditions>
+          <create>true</create>
+          <update>false</update>
+          <delete>false</delete>
+          <changeId>false</changeId>
+        </conditions>
+        <dataset>
+          <name>email</name>
+          <forceValues>
+            <string>srcBean.getDatasetFirstValueById("mail")</string>
+          </forceValues>
+        </dataset>
+        <dataset>
+          <name>firstname</name>
+          <forceValues>
+            <string>srcBean.getDatasetFirstValueById("givenName")</string>
+          </forceValues>
+        </dataset>
+        <dataset>
+          <name>surname</name>
+          <forceValues>
+            <string>srcBean.getDatasetFirstValueById("sn")</string>
+          </forceValues>
+        </dataset>
+      </propertiesBasedSyncOptions>
+    </task>
+  </tasks>
+</lsc>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new integration test that runs services in containers to verify identity synchronization using webadmin password authentication and confirms default identities are created for users.

* **Configuration**
  * Added test-specific webadmin properties and an identity synchronization configuration mapping LDAP attributes to the identity backend.

* **Chores**
  * Updated build and CI settings, including plugin/version and runtime TLS options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->